### PR TITLE
Feature/nodejs

### DIFF
--- a/template/nodejs/flake.lock
+++ b/template/nodejs/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1756696532,
+        "narHash": "sha256-6FWagzm0b7I/IGigOv9pr6LL7NQ86mextfE8g8Q6HBg=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "58dcbf1ec551914c3756c267b8b9c8c86baa1b2f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/template/nodejs/flake.nix
+++ b/template/nodejs/flake.nix
@@ -1,0 +1,44 @@
+{
+  description = "Node pkgs environment";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { nixpkgs, flake-utils, ... }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+        inherit (pkgs) importNpmLock;
+        # Node のバージョンはここで固定
+        nodejs = pkgs.nodejs_24;
+        # package.json / lockfile の場所
+        npmRoot = ./node-pkgs;
+      in
+      {
+        devShells.default = pkgs.mkShell {
+          packages = [
+            importNpmLock.hooks.linkNodeModulesHook
+          ];
+          npmDeps = importNpmLock.buildNodeModules {
+            inherit npmRoot nodejs;
+          };
+        };
+
+        # パッケージ更新作業用の環境
+        devShells.node = pkgs.mkShell {
+          packages = [
+            nodejs
+          ];
+          shellHook = ''
+            cd node-pkgs
+            echo "Node.js version: $(node -v)
+            npm install -D <package-name>@<version> --package-lock-only
+            # npm uninstall -D <package-name> --package-lock-only
+            npm install --package-lock-only"
+          '';
+        };
+      }
+    );
+}

--- a/template/nodejs/flake.nix
+++ b/template/nodejs/flake.nix
@@ -33,10 +33,15 @@
           ];
           shellHook = ''
             cd node-pkgs
-            echo "Node.js version: $(node -v)
+            echo "
+            Node.js version: $(node -v)
+            Add:
             npm install -D <package-name>@<version> --package-lock-only
-            # npm uninstall -D <package-name> --package-lock-only
-            npm install --package-lock-only"
+            Remove:
+            npm uninstall -D <package-name> --package-lock-only
+            Convert package.json to package-lock.json:
+            npm install --package-lock-only
+            "
           '';
         };
       }


### PR DESCRIPTION
This pull request introduces a new Nix flake configuration for setting up and managing a Node.js development environment. The configuration provides reproducible environments using specific Node.js versions and streamlines dependency management with npm lockfiles.

Node.js development environment setup:

* Added a new `flake.nix` file to define a reproducible Node.js environment using Nix flakes, with support for multiple systems and a fixed Node.js version (`nodejs_24`).
* Integrated `importNpmLock` to automatically manage and link `node_modules` based on `package.json` and lockfiles located in the `node-pkgs` directory.

Developer tooling and workflow improvements:

* Provided two development shells: `default` for working with dependencies and `node` for package update workflows, including shell instructions for installing, removing, and converting npm packages and lockfiles.